### PR TITLE
colorize cmake build log

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_COLOR_DIAGNOSTICS ON)
 include(FetchContent)
 FetchContent_Declare(
   googletest


### PR DESCRIPTION
use `set(CMAKE_COLOR_DIAGNOSTICS ON)`.